### PR TITLE
Implement burn card mechanic

### DIFF
--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -401,16 +401,22 @@ export class GameService {
   private completePhase(): void {
     switch (this.gameState.phase) {
       case 'preflop':
+        // Burn one card before dealing the flop
+        this.deckService.dealCards(1, this.deck);
         this.gameState.communityCards = this.deckService.dealCards(3, this.deck);
         this.gameState.phase = 'flop';
         this.resetBettingRound();
         break;
       case 'flop':
+        // Burn one card before dealing the turn
+        this.deckService.dealCards(1, this.deck);
         this.gameState.communityCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.phase = 'turn';
         this.resetBettingRound();
         break;
       case 'turn':
+        // Burn one card before dealing the river
+        this.deckService.dealCards(1, this.deck);
         this.gameState.communityCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.phase = 'river';
         this.resetBettingRound();

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -29,6 +29,7 @@ export class GameService {
       id: Math.random().toString(36).substring(7),
       players: [],
       communityCards: [],
+      burnedCards: [],
       pot: 0,
       currentPlayerId: null,
       currentPlayerPosition: 0,
@@ -61,6 +62,7 @@ export class GameService {
     this.gameState.pot = 0;
     this.gameState.currentBet = 0;
     this.gameState.communityCards = [];
+    this.gameState.burnedCards = [];
     
     // Clear action tracking for new hand
     this.playersActedThisRound.clear();
@@ -402,21 +404,21 @@ export class GameService {
     switch (this.gameState.phase) {
       case 'preflop':
         // Burn one card before dealing the flop
-        this.deckService.dealCards(1, this.deck);
+        this.gameState.burnedCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.communityCards = this.deckService.dealCards(3, this.deck);
         this.gameState.phase = 'flop';
         this.resetBettingRound();
         break;
       case 'flop':
         // Burn one card before dealing the turn
-        this.deckService.dealCards(1, this.deck);
+        this.gameState.burnedCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.communityCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.phase = 'turn';
         this.resetBettingRound();
         break;
       case 'turn':
         // Burn one card before dealing the river
-        this.deckService.dealCards(1, this.deck);
+        this.gameState.burnedCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.communityCards.push(...this.deckService.dealCards(1, this.deck));
         this.gameState.phase = 'river';
         this.resetBettingRound();

--- a/backend/src/types/card.ts
+++ b/backend/src/types/card.ts
@@ -33,6 +33,7 @@ export interface GameState {
   id: string;
   players: Player[];
   communityCards: Card[];
+  burnedCards?: Card[];
   pot: number;
   currentBet: number;
   dealerPosition: number;

--- a/backend/src/types/shared.ts
+++ b/backend/src/types/shared.ts
@@ -40,6 +40,7 @@ export interface GameState {
   id: string;
   players: Player[];
   communityCards: Card[];
+  burnedCards?: Card[];
   pot: number;
   sidePots?: SidePot[];
   currentPlayerId: string | null;

--- a/cypress/e2e/burn-card.cy.ts
+++ b/cypress/e2e/burn-card.cy.ts
@@ -1,0 +1,25 @@
+describe('Burn Card Rule', () => {
+  beforeEach(() => {
+    cy.clearCookies();
+    cy.visit('/');
+  });
+
+  it('should deal correct number of community cards after each phase', () => {
+    cy.get('[data-testid="nickname-input"]').type('BurnTester');
+    cy.get('[data-testid="join-button"]').click();
+
+    cy.get('[data-testid="lobby-container"]').should('be.visible');
+
+    cy.get('[data-testid^="table-"]').first().click();
+    cy.get('[data-testid="buy-in-input"]').should('be.visible');
+    cy.get('[data-testid="nickname-input"]').should('be.visible').clear().type('BurnTester');
+    cy.get('[data-testid="buy-in-input"]').clear().type('100');
+    cy.get('[data-testid="confirm-buy-in"]').should('be.visible').click({ force: true });
+
+    cy.url().should('include', '/game/');
+
+    cy.get('[data-testid="community-cards"]', { timeout: 15000 }).children().should('have.length', 3);
+    cy.get('[data-testid="community-cards"]', { timeout: 15000 }).children().should('have.length', 4);
+    cy.get('[data-testid="community-cards"]', { timeout: 15000 }).children().should('have.length', 5);
+  });
+});

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -15,6 +15,7 @@ export interface GameState {
   players: Player[];
   pot: number;
   communityCards: string[];
+  burnedCards?: string[];
   phase: 'preflop' | 'flop' | 'turn' | 'river' | 'showdown' | 'waiting';
   minBet: number;
   currentBet: number;

--- a/frontend/src/types/shared.ts
+++ b/frontend/src/types/shared.ts
@@ -53,6 +53,7 @@ export interface GameState {
   id: string;
   players: Player[];
   communityCards: Card[];
+  burnedCards?: Card[];
   pot: number;
   sidePots?: SidePot[];
   currentPlayerId: string | null;

--- a/tasks.md
+++ b/tasks.md
@@ -59,6 +59,7 @@
 - [ ] Update socket handlers for game actions
 - [ ] Implement game phase transitions
 - [ ] Add error handling for socket events
+- [x] Implement burn card rule before dealing community cards
 - [x] Fix TypeScript compilation errors (e.g., missing properties in GameState type, type mismatches for Card[] vs string[], missing method implementations in GameService) - COMPLETED: All compilation errors resolved
 
 ### Frontend

--- a/tasks.md
+++ b/tasks.md
@@ -44,6 +44,7 @@
 - [x] Add dealer button movement tests
 - [x] Add game phase transition tests
 - [x] Add blind posting tests
+- [x] Add E2E test for burn card rule
 - [x] Fix jest-dom matchers not available in all test files (e.g., .toBeInTheDocument is not a function)
 - [x] Fix text matching issues for split elements (e.g., 'Players (2)' not found)
 - [x] Fix style/highlight tests failing due to undefined elements (e.g., .toHaveStyle() on undefined)


### PR DESCRIPTION
## Summary
- add missing poker rule: burn card before each street in GameService
- list the completed burn card task in tasks.md

## Testing
- `npm test` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_684109250978832c8e0e1fee2f5bc57c